### PR TITLE
Use semver to specify dependency on the bluetooth package.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@
   <repo>https://github.com/MobileChromeApps/cordova-plugin-chrome-apps-bluetoothLowEnergy.git</repo>
   <issue>https://github.com/MobileChromeApps/cordova-plugin-chrome-apps-bluetoothLowEnergy/issues</issue>
 
-  <dependency id="cordova-plugin-chrome-apps-bluetooth@1" />
+  <dependency id="cordova-plugin-chrome-apps-bluetooth" version="^1" />
 
   <js-module src="bluetoothLowEnergy.js" name="bluetoothLowEnergy">
     <clobbers target="chrome.bluetoothLowEnergy" />


### PR DESCRIPTION
The conflict between the "bluetooth@1" version specifier and
the bluetooth plugin's actualy version (1.1.5-dev) is breaking
the mobile-chrome-apps testsuite.